### PR TITLE
socat-tunneller: update default image tag

### DIFF
--- a/charts/socat-tunneller/Chart.yaml
+++ b/charts/socat-tunneller/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for socat-tunneller
 name: socat-tunneller
-version: 0.1.2
+version: 0.1.3
 home: http://www.dest-unreach.org/socat/
 deprecated: true

--- a/charts/socat-tunneller/values.yaml
+++ b/charts/socat-tunneller/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: alpine/socat
-  tag: 1.0.3
+  tag: 1.0.5
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Update image because a newer patch release exists. Have reviewed the changes and they are a docs change and a no-op.

This is largely just to check that CI handles changes as I would expect.