### PR TITLE
socat-tunneller: un-mark as deprecated in Chart.yaml

### DIFF
--- a/charts/socat-tunneller/Chart.yaml
+++ b/charts/socat-tunneller/Chart.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for socat-tunneller
 name: socat-tunneller
-version: 0.1.4
+version: 0.1.5
 home: http://www.dest-unreach.org/socat/
-deprecated: true
+maintainers:
+  - name: plumdog
+    email: andrew.plummer@isotoma.com


### PR DESCRIPTION
Left-over from copying from stable.