### PR TITLE
Update podsecuritypolicy.yaml

### DIFF
--- a/charts/efs-provisioner/templates/podsecuritypolicy.yaml
+++ b/charts/efs-provisioner/templates/podsecuritypolicy.yaml
@@ -25,6 +25,7 @@ spec:
     - 'configMap'
     - 'secret'
     - 'nfs'
+    - 'projected'
   runAsUser:
     rule: 'RunAsAny'    
   seLinux:


### PR DESCRIPTION
Allow projected volume in psp to overcome forbidden errors while creating pods.

I had below error while creating the pods and had to enable projected volume in psp to overcome the problem

 ```Warning  FailedCreate  27s (x5 over 32s)  replicaset-controller  Error creating: pods "efs-provisioner-bbdbfd5cf-" is forbidden: u │
│ Unable to validate against any pod security policy: [spec.volumes[1]: Invalid value: "nfs": nfs volumes are not allowed to be used sp │
│ ec.volumes[0]: Invalid value: "projected": projected volumes are not allowed to be used] 