### PR TITLE
Better lint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ Charts hosted here: https://isotoma.github.io/charts/
     - Make sure the default values allow the chart to be installed (or CI will fail)
     - And make sure you bump the chart version number (or CI will fail)
 - Can run linting locally with `./tools/lint.sh`
+    - By default, this compares the current branch with `main`, akin to the CI for a PR
+    - Can pass `--all` to lint all charts, but ignoring checks for changes against `main`, eg version bumps
+        - See https://github.com/helm/chart-testing/blob/master/doc/ct_lint.md#options for all options

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker run --rm -it -v $(pwd):/repo --workdir /repo quay.io/helmpack/chart-testing ct lint --config ct.yaml --all
+docker run --rm -it -v $(pwd):/repo --workdir /repo quay.io/helmpack/chart-testing ct lint --config ct.yaml "$@"


### PR DESCRIPTION
Turns out that the `--all` option disables the change-detection, so doesn't mimic the linting done in CI.