### PR TITLE
efs-provisioner: psp with projected

### DIFF
--- a/charts/efs-provisioner/Chart.yaml
+++ b/charts/efs-provisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: efs-provisioner
 description: A Helm chart for the AWS EFS external storage provisioner
-version: 0.13.2
+version: 0.13.3
 appVersion: v2.4.0
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
 sources:

--- a/charts/efs-provisioner/templates/podsecuritypolicy.yaml
+++ b/charts/efs-provisioner/templates/podsecuritypolicy.yaml
@@ -25,6 +25,7 @@ spec:
     - 'configMap'
     - 'secret'
     - 'nfs'
+    - 'projected'
   runAsUser:
     rule: 'RunAsAny'    
   seLinux:


### PR DESCRIPTION
Same as  #9 
Allow projected volume in psp to overcome forbidden errors while creating pods.

I had below error while creating the pods and had to enable projected volume in psp to overcome the problem

```
│ Unable to validate against any pod security policy: [spec.volumes[1]: Invalid value: "nfs": nfs volumes are not allowed to be used sp │
│ ec.volumes[0]: Invalid value: "projected": projected volumes are not allowed to be used] 
```