### PR TITLE
efs-provisioner: Handle apiVersion for StorageClass to support k8s>=1.22

### DIFF
--- a/charts/efs-provisioner/Chart.yaml
+++ b/charts/efs-provisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: efs-provisioner
 description: A Helm chart for the AWS EFS external storage provisioner
-version: 0.13.3
+version: 0.14.0
 appVersion: v2.4.0
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
 sources:

--- a/charts/efs-provisioner/templates/_helpers.tpl
+++ b/charts/efs-provisioner/templates/_helpers.tpl
@@ -37,3 +37,26 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+StorageClass apiVersion
+*/}}
+{{- define "efs-provisioner.storageClassApiVersion" -}}
+{{- with .Values.efsProvisioner.storageClass }}
+{{- /* use an explicit version if set */ -}}
+{{- if .apiVersion -}}
+  {{- .apiVersion -}}
+{{- else -}}
+  {{- /* otherwise, check the candidate versions, and pick the first match found, starting from the top or the bottom of the list, depending on apiVersionPolicy.newestAvailable */ -}}
+  {{- $matchingApiVersion := "" -}}
+  {{- range $candidateApiVersion := (.apiVersionPolicy.newestAvailable | ternary (reverse .apiVersionPolicy.candidateApiVersions) .apiVersionPolicy.candidateApiVersions) -}}
+    {{- if not $matchingApiVersion }}
+      {{- if $.Capabilities.APIVersions.Has (printf "%s/StorageClass" $candidateApiVersion) -}}
+        {{- $matchingApiVersion = $candidateApiVersion -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $matchingApiVersion -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/efs-provisioner/templates/storageclass.yaml
+++ b/charts/efs-provisioner/templates/storageclass.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: {{ (include "efs-provisioner.storageClassApiVersion" .) | required "Unable to determine apiVersion for StorageClass and none explicitly set." }}
 metadata:
   name: {{ .Values.efsProvisioner.storageClass.name }}
   labels:

--- a/charts/efs-provisioner/values.yaml
+++ b/charts/efs-provisioner/values.yaml
@@ -53,6 +53,17 @@ efsProvisioner:
       gidMax: 50000
     reclaimPolicy: Delete
     mountOptions: []
+    # Defaults based on k8s version (see apiVersionPolicy below), or can set explicitly.
+    apiVersion: null
+    apiVersionPolicy:
+      newestAvailable: false
+      # This is an ordered list of api versions that might serve
+      # StorageClass, ordered from oldest to newest. If
+      # newestAvailable is true, use the last one in the list that
+      # does serve StorageClass, otherwise, use the first that does.
+      candidateApiVersions:
+        - storage.k8s.io/v1beta1
+        - storage.k8s.io/v1
 
 ## Enable RBAC
 ##


### PR DESCRIPTION
Fixes #14 

This allows efs-provisioner to support k8s 1.22 and newer by being smarter about the API version, handling the following concerns:
- 1.22 removes `storage.k8s.io/v1beta1/StorageClass`, so should default to `storage.k8s.io/v1/StorageClass` on >=1.22
- however, don't want to use v1 whenever it is available, as this would upgrade the API version for existing releases of the chart, and I'd like to avoid a major version bump
- however, I don't want to require anyone who does want to upgrade, but is on 1.21 to have to hard code an API version. Eg, if you're on 1.21 and are about to upgrade to 1.22.

Therefore, have added the option to force a certain API version, or can choose whether to be on the oldest supported version (this is the default, so retains backwards compatibility) or newest supported version (this will make for easier cluster upgrades).