### PR TITLE
Cronjobber: support k8s >= 1.22

### DIFF
--- a/charts/cronjobber/Chart.yaml
+++ b/charts/cronjobber/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cronjobber
 home: https://github.com/hiddeco/cronjobber
-version: 0.1.1
+version: 0.2.0
 appVersion: 0.3.0
 description: Cronjobber is the cronjob controller from Kubernetes patched with time zone support.
 maintainers:

--- a/charts/cronjobber/README.md
+++ b/charts/cronjobber/README.md
@@ -32,6 +32,12 @@ The following table lists the configurable parameters of the cronjobber chart an
 | `sidecar.image.tag`     | Sidecar and init container image tag  | `0.1.1`                                                    |
 | `sidecar.resources.requests.cpu`| Sidecar and init container cpu request | `100m`                                            |
 | `sidecar.resources.requests.memory`| Sidecar and init container memory request | `64Mi`                                      |
+| `rbac.apiVersion`                            | Specify an API version for RBAC resources     |                                                                     |
+| `rbac.apiVersionPolicy.newestAvailable`      | Use the newest candidate version available    | `false`                                                             |
+| `rbac.apiVersionPolicy.candidateApiVersions` | List of API versions to check for, old to new | `rbac.authorization.k8s.io/v1beta1`, `rbac.authorization.k8s.io/v1` |
+| `crd.apiVersion`                             | Specify an API version for the CRD resource   |                                                                     |
+| `crd.apiVersionPolicy.newestAvailable`       | Use the newest candidate version available    | `false`                                                             |
+| `crd.apiVersionPolicy.candidateApiVersions`  | List of API versions to check for, old to new | `apiextensions.k8s.io/v1beta1`, `apiextensions.k8s.io/v1`           |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/charts/cronjobber/templates/_helpers.tpl
+++ b/charts/cronjobber/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Dynamic apiVersion resolution
+*/}}
+{{- define "cronjobber._dynamicApiVersionResolution" -}}
+{{- /* use an explicit version if set */ -}}
+{{- if ._args.apiVersion -}}
+  {{- ._args.apiVersion -}}
+{{- else -}}
+  {{- /* otherwise, check the candidate versions, and pick the first match found, starting from the top or the bottom of the list, depending on apiVersionPolicy.newestAvailable */ -}}
+  {{- $matchingApiVersion := "" -}}
+  {{- $resourceType := ._args._resourceType }}
+  {{- range $candidateApiVersion := (._args.apiVersionPolicy.newestAvailable | ternary (reverse ._args.apiVersionPolicy.candidateApiVersions) ._args.apiVersionPolicy.candidateApiVersions) -}}
+    {{- if not $matchingApiVersion }}
+      {{- if $.Capabilities.APIVersions.Has (printf "%s/%s" $candidateApiVersion $resourceType) -}}
+        {{- $matchingApiVersion = $candidateApiVersion -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $matchingApiVersion -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+RBAC apiVersion
+*/}}
+{{- define "cronjobber.rbacApiVersion" -}}
+{{- $_ := set . "_args" (.Values.rbac | deepCopy | merge (dict "_resourceType" "ClusterRole")) -}}
+{{- include "cronjobber._dynamicApiVersionResolution" . }}
+{{- $_ := unset . "_args" -}}
+{{- end -}}
+
+{{/*
+CRD apiVersion
+*/}}
+{{- define "cronjobber.crdApiVersion" -}}
+{{- $_ := set . "_args" (.Values.crd | deepCopy | merge (dict "_resourceType" "CustomResourceDefinition")) -}}
+{{- include "cronjobber._dynamicApiVersionResolution" . }}
+{{- $_ := unset . "_args" -}}
+{{- end -}}
+
+{{/*
+CRD additional printer columns
+*/}}
+{{- define "cronjobber.crdAdditionalPrinterColumns" -}}
+{{- $apiVersion := (include "cronjobber.crdApiVersion" .) | required "Unable to determine apiVersion for CustomResourceDefinition and none explicitly set." -}}
+{{- $jsonPath := (eq $apiVersion "apiextensions.k8s.io/v1beta1") | ternary "JSONPath" "jsonPath" -}}
+- name: Schedule
+  type: string
+  description: The schedule defining the interval a TZCronJob is run
+  {{ $jsonPath }}: .spec.schedule
+- name: Time zone
+  type: string
+  description: The time zone the interval of a TZCronJob is calculated in
+  {{ $jsonPath }}: .spec.timezone
+- name: Last schedule
+  type: date
+  description: The last time a Job was scheduled by a TZCronJob
+  {{ $jsonPath }}: .status.lastScheduleTime
+- name: Age
+  type: date
+  {{ $jsonPath }}: .metadata.creationTimestamp
+{{- end -}}

--- a/charts/cronjobber/templates/clusterrole.yaml
+++ b/charts/cronjobber/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ (include "cronjobber.rbacApiVersion" .) | required "Unable to determine RBAC apiVersion for ClusterRole and none explicitly set." }}
 kind: ClusterRole
 metadata:
   name: {{ .Values.name }}

--- a/charts/cronjobber/templates/clusterrolebinding.yaml
+++ b/charts/cronjobber/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ (include "cronjobber.rbacApiVersion" .) | required "Unable to determine RBAC apiVersion for ClusterRoleBinding and none explicitly set." }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.name }}

--- a/charts/cronjobber/templates/customresourcedefinition.yaml
+++ b/charts/cronjobber/templates/customresourcedefinition.yaml
@@ -1,11 +1,14 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+{{ $apiVersion := (include "cronjobber.crdApiVersion" .) | required "Unable to determine apiVersion for CustomResourceDefinition and none explicitly set." }}
+apiVersion: {{ $apiVersion }}
 kind: CustomResourceDefinition
 metadata:
   name: tzcronjobs.cronjobber.hidde.co
 spec:
   group: cronjobber.hidde.co
+  {{- if eq $apiVersion "apiextensions.k8s.io/v1beta1" }}
   version: v1alpha1
+  {{- end }}
   names:
     plural: tzcronjobs
     singular: tzcronjob
@@ -14,21 +17,17 @@ spec:
     shortNames:
       - tzc
   scope: Namespaced
+  {{- if eq $apiVersion "apiextensions.k8s.io/v1beta1" }}
   subresources:
     status: {}
-  additionalPrinterColumns:
-    - name: Schedule
-      type: string
-      description: The schedule defining the interval a TZCronJob is run
-      JSONPath: .spec.schedule
-    - name: Time zone
-      type: string
-      description: The time zone the interval of a TZCronJob is calculated in
-      JSONPath: .spec.timezone
-    - name: Last schedule
-      type: date
-      description: The last time a Job was scheduled by a TZCronJob
-      JSONPath: .status.lastScheduleTime
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
+  additionalPrinterColumns: {{- include "cronjobber.crdAdditionalPrinterColumns" . | nindent 4 }}
+  {{- end }}
+  {{- if eq $apiVersion "apiextensions.k8s.io/v1" }}
+  versions:
+    - additionalPrinterColumns: {{- include "cronjobber.crdAdditionalPrinterColumns" . | nindent 8 }}
+      name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  {{- end }}

--- a/charts/cronjobber/values.yaml
+++ b/charts/cronjobber/values.yaml
@@ -26,3 +26,19 @@ sidecar:
       drop:
         - ALL
 nodeSelector: {}
+
+rbac:
+  apiVersion: null
+  apiVersionPolicy:
+    newestAvailable: false
+    candidateApiVersions:
+      - rbac.authorization.k8s.io/v1beta1
+      - rbac.authorization.k8s.io/v1
+
+crd:
+  apiVersion: null
+  apiVersionPolicy:
+    newestAvailable: false
+    candidateApiVersions:
+      - apiextensions.k8s.io/v1beta1
+      - apiextensions.k8s.io/v1


### PR DESCRIPTION
Akin to #15.

By default, will continue to use the same API versions, but allows control of which API versions are used.