### PR TITLE
Cronjobber: changes to some default values

### DIFF
--- a/charts/cronjobber/Chart.yaml
+++ b/charts/cronjobber/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cronjobber
 home: https://github.com/hiddeco/cronjobber
-version: 0.3.0
+version: 0.4.0
 appVersion: 0.3.0
 description: Cronjobber is the cronjob controller from Kubernetes patched with time zone support.
 maintainers:

--- a/charts/cronjobber/README.md
+++ b/charts/cronjobber/README.md
@@ -16,18 +16,16 @@ The following table lists the configurable parameters of the cronjobber chart an
 | `image.repository`                           | Container image name                             | `quay.io/hiddeco/cronjobber`                                        |
 | `image.tag`                                  | Container image tag                              | `0.3.0`                                                             |
 | `replicas`                                   | Number of replicas                               | `1`                                                                 |
-| `resources.requests.cpu`                     | CPU request for the main container               | `50m`                                                               |
-| `resources.requests.memory`                  | Memory request for the main container            | `64Mi`                                                              |
+| `resources`                                  | Resources for the main container                 | `{}`                                                                |
 | `sidecar.enabled`                            | Sidecar to keep the timezone database up-to-date | `False`                                                             |
 | `sidecar.image.repository`                   | Sidecar and init container image name            | `quay.io/hiddeco/cronjobber-updatetz`                               |
 | `sidecar.image.tag`                          | Sidecar and init container image tag             | `0.1.1`                                                             |
-| `sidecar.resources.requests.cpu`             | Sidecar and init container cpu request           | `100m`                                                              |
-| `sidecar.resources.requests.memory`          | Sidecar and init container memory request        | `64Mi`                                                              |
+| `sidecar.resources`                          | Sidecar and init container resources             | `{}`                                                                |
 | `rbac.apiVersion`                            | Specify an API version for RBAC resources        |                                                                     |
-| `rbac.apiVersionPolicy.newestAvailable`      | Use the newest candidate version available       | `false`                                                             |
+| `rbac.apiVersionPolicy.newestAvailable`      | Use the newest candidate version available       | `true`                                                              |
 | `rbac.apiVersionPolicy.candidateApiVersions` | List of API versions to check for, old to new    | `rbac.authorization.k8s.io/v1beta1`, `rbac.authorization.k8s.io/v1` |
 | `crd.apiVersion`                             | Specify an API version for the CRD resource      |                                                                     |
-| `crd.apiVersionPolicy.newestAvailable`       | Use the newest candidate version available       | `false`                                                             |
+| `crd.apiVersionPolicy.newestAvailable`       | Use the newest candidate version available       | `true`                                                              |
 | `crd.apiVersionPolicy.candidateApiVersions`  | List of API versions to check for, old to new    | `apiextensions.k8s.io/v1beta1`, `apiextensions.k8s.io/v1`           |
 
 ## Usage

--- a/charts/cronjobber/templates/deployment.yaml
+++ b/charts/cronjobber/templates/deployment.yaml
@@ -34,10 +34,7 @@ spec:
           image: {{ printf "%s:%s" .Values.sidecar.image.repository .Values.sidecar.image.tag | quote }}
           securityContext:
 {{ toYaml .Values.sidecar.securityContext | indent 12 }}
-          resources:
-            limits:
-              cpu: {{ .Values.sidecar.resources.requests.cpu }}
-              memory: {{ .Values.sidecar.resources.requests.memory }}
+          resources: {{- .Values.sidecar.resources | toYaml | nindent 12 }}
           volumeMounts:
             - name: timezonedb
               mountPath: /tmp/zoneinfo
@@ -51,10 +48,7 @@ spec:
       containers:
         - name: cronjobber
           image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | quote }}
-          resources:
-            requests:
-              cpu: {{ .Values.resources.requests.cpu }}
-              memory: {{ .Values.resources.requests.memory }}
+          resources: {{- .Values.resources | toYaml | nindent 12 }}
           args:
             - --log-level=info
           {{- if .Values.sidecar.enabled }}
@@ -70,10 +64,7 @@ spec:
           # out of the box on OpenShift
           securityContext:
 {{ toYaml .Values.sidecar.securityContext | indent 12 }}
-          resources:
-            limits:
-              cpu: {{ .Values.sidecar.resources.requests.cpu }}
-              memory: {{ .Values.sidecar.resources.requests.memory }}
+          resources: {{- .Values.sidecar.resources | toYaml | nindent 12 }}
           volumeMounts:
             - name: timezonedb
               mountPath: /tmp/zoneinfo

--- a/charts/cronjobber/values.yaml
+++ b/charts/cronjobber/values.yaml
@@ -13,19 +13,13 @@ image:
   repository: quay.io/hiddeco/cronjobber
   tag: 0.3.0
 replicas: 1
-resources:
-  requests:
-    cpu: 50m
-    memory: 64Mi
+resources: {}
 sidecar:
   enabled: false
   image:
     repository: quay.io/hiddeco/cronjobber-updatetz
     tag: 0.1.1
-  resources:
-    requests:
-      cpu: 100m
-      memory: 64Mi
+  resources: {}
   # NB: the security context configuration below may not work
   # out of the box on OpenShift
   securityContext:
@@ -38,7 +32,7 @@ nodeSelector: {}
 rbac:
   apiVersion: null
   apiVersionPolicy:
-    newestAvailable: false
+    newestAvailable: true
     candidateApiVersions:
       - rbac.authorization.k8s.io/v1beta1
       - rbac.authorization.k8s.io/v1
@@ -46,7 +40,7 @@ rbac:
 crd:
   apiVersion: null
   apiVersionPolicy:
-    newestAvailable: false
+    newestAvailable: true
     candidateApiVersions:
       - apiextensions.k8s.io/v1beta1
       - apiextensions.k8s.io/v1


### PR DESCRIPTION
- default to no resource requests or limits (but allow setting limits as well as requests)
- default to newest available API versions for RBAC and CRD.